### PR TITLE
Python 3 migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.0b1.dev0 (unreleased)
+-----------------------
+
+- Migrate to Python 3
+  [daggelpop]
+
 
 1.0b4 (2017-11-15)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = collective.ttwpo
-version = 1.0b4
+version = 2.0b1.dev0
 description = Manage your PO Translation Files TTW and Sync with Translationservices
 long_description = file: README.rst, CHANGES.rst, LICENSE.rst
 keywords = Python Plone Translation PO gettext ttwpo
@@ -11,9 +11,9 @@ license = GNU General Public License v2 (GPLv2)
 classifiers =
     Environment :: Web Environment
     Framework :: Plone
-    Framework :: Plone :: 5.1
+    Framework :: Plone :: 5.2
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
     Operating System :: OS Independent
     License :: OSI Approved :: GNU General Public License v2 (GPLv2)
 

--- a/src/collective/ttwpo/gettextmessagecatalog.py
+++ b/src/collective/ttwpo/gettextmessagecatalog.py
@@ -5,7 +5,6 @@ from persistent import Persistent
 from pythongettext.msgfmt import Msgfmt
 from zope.i18n.gettextmessagecatalog import _KeyErrorRaisingFallback
 from zope.i18n.gettextmessagecatalog import GettextMessageCatalog
-from zope.i18n.gettextmessagecatalog import PY2
 
 _marker = dict()
 
@@ -24,8 +23,6 @@ class LocalGettextMessageCatalog(Persistent, GettextMessageCatalog):
 
     @property
     def _gettext(self):
-        if PY2:
-            return self._catalog.ugettext
         return self._catalog.gettext
 
     @property
@@ -54,7 +51,7 @@ class LocalGettextMessageCatalog(Persistent, GettextMessageCatalog):
     def _compiled_mo(self):
         """turns a locale storage current PO into a MO as stringio"""
         datalines = [
-            l for l in self.locale_storage().split('\n')
+            l for l in self.locale_storage().split(b'\n')
             if l.strip()
         ]
         mf = Msgfmt(datalines, name=self.domain)

--- a/src/collective/ttwpo/storage.py
+++ b/src/collective/ttwpo/storage.py
@@ -48,7 +48,7 @@ class LocaleStorage(object):
         """data of version
         """
         data = self.storage[version].data
-        if isinstance(data, str):
+        if isinstance(data, bytes):
             return data
 
         # we load the beast in memory - po files houldnt be too big, right?

--- a/src/collective/ttwpo/tests/data.py
+++ b/src/collective/ttwpo/tests/data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-TEST_PO_DE = """\
+TEST_PO_DE = b"""\
 # Translation of testdomain.pot to German
 msgid ""
 msgstr ""
@@ -31,7 +31,7 @@ msgstr "$d Tage und $h Stunden"
 
 """
 
-TEST_PO_DE_2 = """\
+TEST_PO_DE_2 = b"""\
 # Translation of testdomain.pot to German
 msgid ""
 msgstr ""

--- a/src/collective/ttwpo/tests/test_api.py
+++ b/src/collective/ttwpo/tests/test_api.py
@@ -44,8 +44,8 @@ class TestApi(unittest.TestCase):
         from collective.ttwpo.storage import I18NDomainStorage
         zd = I18NDomainStorage('testdomain')
         zd.settings['foo'] = 'bar'
-        zd.locale('de').set_version('v1', '#testdata1')
-        zd.locale('de').set_version('v2', '#testdata2')
+        zd.locale('de').set_version('v1', b'#testdata1')
+        zd.locale('de').set_version('v2', b'#testdata2')
         zd.locale('de').current = 'v2'
         self.assertDictEqual(
             api.info('testdomain'),
@@ -68,7 +68,7 @@ class TestApi(unittest.TestCase):
                 'de',
                 'v1',
                 current=True,
-                data='#testdata1'
+                data=b'#testdata1'
             )
 
     def test_update_locale_nonexisting_locale(self):
@@ -80,7 +80,7 @@ class TestApi(unittest.TestCase):
                 'de',
                 'v1',
                 current=True,
-                data='#testdata1'
+                data=b'#testdata1'
             )
 
     def test_update_locale_initial_non_current(self):
@@ -91,7 +91,7 @@ class TestApi(unittest.TestCase):
             'de',
             'v1',
             current=True,
-            data='#testdata1'
+            data=b'#testdata1'
         )
         from zope.component import queryUtility
         from zope.i18n import ITranslationDomain
@@ -186,7 +186,7 @@ class TestApi(unittest.TestCase):
                 lang,
                 'v1',
                 current=True,
-                data='#testdata1 {0}'.format(lang)
+                data='#testdata1 {0}'.format(lang).encode()
             )
         from zope.component import queryUtility
         from zope.i18n import ITranslationDomain
@@ -250,7 +250,7 @@ class TestApi(unittest.TestCase):
                 lang,
                 'v1',
                 current=False,
-                data='#testdata1 {0}'.format(lang)
+                data='#testdata1 {0}'.format(lang).encode()
             )
         from collective.ttwpo.storage import I18NDomainStorage
         zd = I18NDomainStorage('testdomain')
@@ -274,7 +274,7 @@ class TestApi(unittest.TestCase):
                 lang,
                 'v1',
                 current=True,
-                data='#testdata1 {0}'.format(lang)
+                data='#testdata1 {0}'.format(lang).encode()
             )
         from collective.ttwpo.storage import I18NDomainStorage
         zd = I18NDomainStorage('testdomain')

--- a/src/collective/ttwpo/tests/test_gettextmsgcat.py
+++ b/src/collective/ttwpo/tests/test_gettextmsgcat.py
@@ -45,11 +45,11 @@ class TestTranslationDomain(unittest.TestCase):
         mo = lm._compiled_mo()
         modata = mo.read()
         self.assertIn(
-            '\xde\x12\x04',
+            b'\xde\x12\x04',
             modata,
         )
         self.assertIn(
-            'Columbo',
+            b'Columbo',
             modata,
         )
 

--- a/src/collective/ttwpo/tests/test_setup.py
+++ b/src/collective/ttwpo/tests/test_setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+from Products.CMFPlone.utils import get_installer
 from collective.ttwpo.testing import COLLECTIVE_ZANATA_INTEGRATION_TESTING  # noqa
 from plone import api
 from plone.app.testing import setRoles
@@ -16,11 +17,11 @@ class TestSetup(unittest.TestCase):
     def setUp(self):
         """Custom shared utility setup for tests."""
         self.portal = self.layer['portal']
-        self.installer = api.portal.get_tool('portal_quickinstaller')
+        self.installer = get_installer(self.portal)
 
     def test_product_installed(self):
         """Test if collective.ttwpo is installed."""
-        self.assertTrue(self.installer.isProductInstalled(
+        self.assertTrue(self.installer.is_product_installed(
             'collective.ttwpo'))
 
     def test_browserlayer(self):
@@ -43,7 +44,7 @@ class TestUninstall(unittest.TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
-        self.installer = api.portal.get_tool('portal_quickinstaller')
+        self.installer = get_installer(self.portal)
         roles_before = api.user.get(userid=TEST_USER_ID).getRoles()
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         self.installer.uninstallProducts(['collective.ttwpo'])
@@ -51,7 +52,7 @@ class TestUninstall(unittest.TestCase):
 
     def test_product_uninstalled(self):
         """Test if collective.ttwpo is cleanly uninstalled."""
-        self.assertFalse(self.installer.isProductInstalled(
+        self.assertFalse(self.installer.is_product_installed(
             'collective.ttwpo'))
 
     def test_browserlayer_removed(self):

--- a/src/collective/ttwpo/tests/test_storage.py
+++ b/src/collective/ttwpo/tests/test_storage.py
@@ -41,9 +41,9 @@ class TestStorage(unittest.TestCase):
         zd = I18NDomainStorage('testdomain')
         lang = zd.locale('de')
 
-        lang.set_version('one', 'some test data')
+        lang.set_version('one', b'some test data')
         self.assertIn('one', lang.storage)
-        self.assertEqual(lang.get_version('one'), 'some test data')
+        self.assertEqual(lang.get_version('one'), b'some test data')
 
     def test_locale_current(self):
         from collective.ttwpo.storage import I18NDomainStorage
@@ -54,12 +54,12 @@ class TestStorage(unittest.TestCase):
         with self.assertRaises(ValueError):
             lang.current = 'nonexisting'
 
-        lang.set_version('existing', 'some test data')
-        self.assertEqual(lang.get_version('existing'), 'some test data')
+        lang.set_version('existing', b'some test data')
+        self.assertEqual(lang.get_version('existing'), b'some test data')
 
         lang.current = 'existing'
         self.assertEqual(lang.current, 'existing')
-        self.assertEqual(lang(), 'some test data')
+        self.assertEqual(lang(), b'some test data')
 
     def test_locales_empty(self):
         from collective.ttwpo.storage import I18NDomainStorage
@@ -78,6 +78,6 @@ class TestStorage(unittest.TestCase):
         zd = I18NDomainStorage('testdomain')
         zd.locale('it')
         lang_de = zd.locale('de')
-        lang_de.set_version('v1', 'some test data')
+        lang_de.set_version('v1', b'some test data')
         lang_de.current = 'v1'
         self.assertListEqual(zd.locales, ['de'])


### PR DESCRIPTION
The core functionality works fine.

I didn't check the Zanata part, I have no use for it.

All the tests are passing (Plone 5.2 / Python 3.8).

@mpeeters If it's OK for you, can you release it on PyPI ?